### PR TITLE
#23 Color and Upload Controllers for the Customizer

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -10,6 +10,13 @@
 
           <div class="col_half">
             <?php echo get_theme_mod('wpt_footer_copyright_text');?><br>
+            <?php 
+              if(get_theme_mod('wpt_report_file')){
+                ?>
+                <a href="<?php echo get_theme_mod('wpt_report_file');?>">Download Report</a><br>
+                <?php
+              }
+            ?>
             <div class="copyright-links">
               <?php 
                 if(get_theme_mod('wpt_footer_tos_page')){

--- a/includes/customizer/misc.php
+++ b/includes/customizer/misc.php
@@ -31,6 +31,16 @@ $wp_customize->add_setting('wpt_footer_privacy_page',
     'default' => '0'
 ]);
 
+$wp_customize->add_setting('wpt_read_more_color', 
+[
+    'default' => '#1ABC9C'
+]);
+
+$wp_customize->add_setting('wpt_report_file', 
+[
+    'default' => ''
+]);
+
 
 //Create a section that will hold all our controllers
 $wp_customize->add_section('wpt_misc_section',
@@ -108,4 +118,29 @@ $wp_customize->add_control(new WP_Customize_Control(
         'type' => 'dropdown-pages',
     )
     ));
+
+//Read More controller
+$wp_customize->add_control(new WP_Customize_Color_Control(
+    $wp_customize, 
+    'wpt_read_more_color_input',
+
+    array('label' => __('Read More Link Color', 'wp-theme-dev'),
+        'section' => 'wpt_misc_section',
+        'settings' => 'wpt_read_more_color',
+    )
+
+));
+//Upload Control
+
+$wp_customize->add_control(new WP_Customize_Upload_Control(
+    $wp_customize, 
+    'wpt_report_file_input',
+
+    array('label' => __('File Report', 'wp-theme-dev'),
+        'section' => 'wpt_misc_section',
+        'settings' => 'wpt_report_file',
+    )
+
+));
 }
+

--- a/includes/front/enqueue.php
+++ b/includes/front/enqueue.php
@@ -26,6 +26,11 @@ function wpt_enqueue(){
     wp_enqueue_style('wpt_responsive');
     wp_enqueue_style('wpt_custom');
     
+    $read_more_color = get_theme_mod('wpt_read_more_color');
+    wp_add_inline_style(
+        'wpt_custom',
+        'a.more-link{color: '. $read_more_color. '; border-color: '.$read_more_color.';}'
+    );
 
     wp_register_script('wpt_plugins', $uri.'/assets/js/plugins.js', [],$ver, true);
     wp_register_script('wpt_functions', $uri.'/assets/js/functions.js', [],$ver, true);


### PR DESCRIPTION
## What does this PR do?
1. Creates control for readme link to change color using the theme-customizer
2. Creates control for upload document link in the footer using the theme-customizer

## Description of Task to be completed?
1. Create a setting for Read More Link in includes/customizer/misc.php with the color control
2. Create a setting for Upload File Link in includes/customizer/misc.php
3. Create a controller for the Read More Setting
4. Create a controller for the Upload Setting
5. Use the wp_add_inline _style() function to change the color.

## How should this be manually tested?
1. As a Wordpress theme, download the zip file and install it into your local or online Wordpress website.
2. Activate the theme.
3. Add menu items to Primary menu in WordPress Dashboard
4. View the website.
5. Go to customizer
6. Go to WP Theme Dev->Misc Settings
7. Change color for Read More link
8. Upload a file and view the footer section
9. You can publish and view the website with its new setting.
