### PR TITLE
#27 Woocommerce support for the theme setup

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -21,7 +21,8 @@ add_action('customize_register', 'wpt_customize_register');
 //This hook will only run if the customizer is loaded
 //Its purpose is for loading stylesheets and scripts only
 add_action('customize_preview_init', 'wpt_customize_preview_init');
-
+remove_action('woocommerce_sidebar', 'woocommerce_get_sidebar', 10);
+//remove_action('woocommerce_before_shop_loop', 'woocommerce_catalog_ordering', 30);
 
 
 //Shortcodes

--- a/header.php
+++ b/header.php
@@ -179,38 +179,63 @@
             ============================================= -->
             
             <div id="top-cart">
-              <a href="#" id="top-cart-trigger"><i class="icon-shopping-cart"></i><span>5</span></a>
+              <a href="#" id="top-cart-trigger"><i class="icon-shopping-cart"></i>
+              <span>
+              <?php echo WC()->cart->get_cart_contents_count();?>
+              </span></a>
               <div class="top-cart-content">
                 <div class="top-cart-title">
                   <h4>Shopping Cart</h4>
                 </div>
                 <div class="top-cart-items">
-                  <div class="top-cart-item clearfix">
-                    <div class="top-cart-item-image">
-                      <a href="#"><img src="images/shop/small/1.jpg" /></a>
-                    </div>
-                    <div class="top-cart-item-desc">
-                      <a href="#">Blue Round-Neck Tshirt</a>
-                      <span class="top-cart-item-price">$19.99</span>
-                      <span class="top-cart-item-quantity">x 2</span>
-                    </div>
-                  </div>
-                  <div class="top-cart-item clearfix">
-                    <div class="top-cart-item-image">
-                      <a href="#"><img src="images/shop/small/6.jpg" /></a>
-                    </div>
-                    <div class="top-cart-item-desc">
-                      <a href="#">Light Blue Denim Dress</a>
-                      <span class="top-cart-item-price">$24.99</span>
-                      <span class="top-cart-item-quantity">x 3</span>
-                    </div>
-                  </div>
+                <?php
+                  foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
+                    $_product   = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
+                    $product_id = apply_filters( 'woocommerce_cart_item_product_id', $cart_item['product_id'], $cart_item, $cart_item_key );
+
+                    if ( $_product && $_product->exists() && $cart_item['quantity'] > 0 && apply_filters( 'woocommerce_cart_item_visible', true, $cart_item, $cart_item_key ) ) {
+                      $product_permalink = apply_filters( 'woocommerce_cart_item_permalink', $_product->is_visible() ? $_product->get_permalink( $cart_item ) : '', $cart_item, $cart_item_key );
+                      ?>
+                      <div class="top-cart-item clearfix">
+                        <div class="top-cart-item-image">
+                        <?php
+                        $thumbnail = apply_filters( 'woocommerce_cart_item_thumbnail', $_product->get_image(), $cart_item, $cart_item_key );
+
+                        if ( ! $product_permalink ) {
+                          echo $thumbnail; // PHPCS: XSS ok.
+                        } else {
+                          printf( '<a href="%s">%s</a>', esc_url( $product_permalink ), $thumbnail ); // PHPCS: XSS ok.
+                        }
+                        ?>
+                        </div>
+                        <div class="top-cart-item-desc">
+                          
+                          <?php
+                        if ( ! $product_permalink ) {
+                          echo wp_kses_post( apply_filters( 'woocommerce_cart_item_name', $_product->get_name(), $cart_item, $cart_item_key ) . '&nbsp;' );
+                        } else {
+                          echo wp_kses_post( apply_filters( 'woocommerce_cart_item_name', sprintf( '<a href="%s">%s</a>', esc_url( $product_permalink ), $_product->get_name() ), $cart_item, $cart_item_key ) );
+                        }
+                        ?>
+                          
+                          <span class="top-cart-item-price">
+                          <?php
+                            echo apply_filters( 'woocommerce_cart_item_price', WC()->cart->get_product_price( $_product ), $cart_item, $cart_item_key ); // PHPCS: XSS ok.
+                          ?>
+                          </span>
+                          <span class="top-cart-item-quantity"><?php echo $cart_item['quantity'];?></span>
+                        </div>
+                      </div>
+                     <?php
+                    }
+                  }
+                  ?>
                 </div>
                 <div class="top-cart-action clearfix">
-                  <span class="fleft top-checkout-price">$114.95</span>
-                  <button class="button button-3d button-small nomargin fright">
+                  <span class="fleft top-checkout-price"><?php echo WC()->cart->get_cart_total();?></span>
+                  <a href="<php echo wc_get_cart_url();?>" class="button button-3d button-small nomargin fright">
                     View Cart
-                  </button>
+                  </a>
                 </div>
               </div>
             </div><!-- #top-cart end -->

--- a/includes/setup.php
+++ b/includes/setup.php
@@ -107,6 +107,9 @@ function wpt_setup_theme(){
 
     ]);
 
+    //Woocommerce support
+    add_theme_support('woocommerce');
+
 
     //WP Quads code
     if (function_exists('quads_register_ad')){

--- a/woocommerce/cart/proceed-to-checkout-button.php
+++ b/woocommerce/cart/proceed-to-checkout-button.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Proceed to checkout button
+ *
+ * Contains the markup for the proceed to checkout button on the cart.
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/cart/proceed-to-checkout-button.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see     https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates
+ * @version 2.4.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+?>
+
+<a href="<?php echo esc_url( wc_get_checkout_url() ); ?>" class="btn btn-block btn-lg btn-primary">
+	<?php esc_html_e( 'Proceed to checkout', 'woocommerce' ); ?>
+</a>

--- a/woocommerce/checkout/form-billing.php
+++ b/woocommerce/checkout/form-billing.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Checkout billing information form
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/checkout/form-billing.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see     https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates
+ * @version 3.6.0
+ * @global WC_Checkout $checkout
+ */
+
+defined( 'ABSPATH' ) || exit;
+?>
+<div class="woocommerce-billing-fields">
+	<?php if ( wc_ship_to_billing_address_only() && WC()->cart->needs_shipping() ) : ?>
+
+		<h3><?php esc_html_e( 'Billing &amp; Shipping', 'woocommerce' ); ?></h3>
+
+	<?php else : ?>
+
+		<h3><?php esc_html_e( 'Billing details', 'woocommerce' ); ?></h3>
+
+	<?php endif; ?>
+
+	<?php do_action( 'woocommerce_before_checkout_billing_form', $checkout ); ?>
+
+	<div class="woocommerce-billing-fields__field-wrapper">
+		<?php
+		$fields = $checkout->get_checkout_fields( 'billing' );
+
+		foreach ( $fields as $key => $field ) {
+			$field['class'][] = 'form-group'; 
+
+            $field['input_class'][] = 'form-control';
+			woocommerce_form_field( $key, $field, $checkout->get_value( $key ) );
+		}
+		?>
+	</div>
+
+	<?php do_action( 'woocommerce_after_checkout_billing_form', $checkout ); ?>
+</div>
+
+<?php if ( ! is_user_logged_in() && $checkout->is_registration_enabled() ) : ?>
+	<div class="woocommerce-account-fields">
+		<?php if ( ! $checkout->is_registration_required() ) : ?>
+
+			<p class="form-row form-row-wide create-account">
+				<label class="woocommerce-form__label woocommerce-form__label-for-checkbox checkbox">
+					<input class="woocommerce-form__input woocommerce-form__input-checkbox input-checkbox" id="createaccount" <?php checked( ( true === $checkout->get_value( 'createaccount' ) || ( true === apply_filters( 'woocommerce_create_account_default_checked', false ) ) ), true ); ?> type="checkbox" name="createaccount" value="1" /> <span><?php esc_html_e( 'Create an account?', 'woocommerce' ); ?></span>
+				</label>
+			</p>
+
+		<?php endif; ?>
+
+		<?php do_action( 'woocommerce_before_checkout_registration_form', $checkout ); ?>
+
+		<?php if ( $checkout->get_checkout_fields( 'account' ) ) : ?>
+
+			<div class="create-account">
+				<?php foreach ( $checkout->get_checkout_fields( 'account' ) as $key => $field ) : ?>
+					<?php woocommerce_form_field( $key, $field, $checkout->get_value( $key ) ); ?>
+				<?php endforeach; ?>
+				<div class="clear"></div>
+			</div>
+
+		<?php endif; ?>
+
+		<?php do_action( 'woocommerce_after_checkout_registration_form', $checkout ); ?>
+	</div>
+<?php endif; ?>

--- a/woocommerce/checkout/form-checkout.php
+++ b/woocommerce/checkout/form-checkout.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Checkout Form
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/checkout/form-checkout.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates
+ * @version 3.5.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+do_action( 'woocommerce_before_checkout_form', $checkout );
+
+// If checkout registration is disabled and not logged in, the user cannot checkout.
+if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_required() && ! is_user_logged_in() ) {
+	echo esc_html( apply_filters( 'woocommerce_checkout_must_be_logged_in_message', __( 'You must be logged in to checkout.', 'woocommerce' ) ) );
+	return;
+}
+
+?>
+
+<form name="checkout" method="post" class="checkout woocommerce-checkout" action="<?php echo esc_url( wc_get_checkout_url() ); ?>" enctype="multipart/form-data">
+
+	<?php if ( $checkout->get_checkout_fields() ) : ?>
+
+		<?php do_action( 'woocommerce_checkout_before_customer_details' ); ?>
+
+		<div class="col2-set row" id="customer_details">
+			<div class="col-12">
+				<?php do_action( 'woocommerce_checkout_billing' ); ?>
+			</div>
+
+			<div class="col-12">
+				<?php do_action( 'woocommerce_checkout_shipping' ); ?>
+			</div>
+		</div>
+
+		<?php do_action( 'woocommerce_checkout_after_customer_details' ); ?>
+
+	<?php endif; ?>
+	
+	<?php do_action( 'woocommerce_checkout_before_order_review_heading' ); ?>
+	
+	<h3 id="order_review_heading"><?php esc_html_e( 'Your order', 'woocommerce' ); ?></h3>
+	
+	<?php do_action( 'woocommerce_checkout_before_order_review' ); ?>
+
+	<div id="order_review" class="woocommerce-checkout-review-order">
+		<?php do_action( 'woocommerce_checkout_order_review' ); ?>
+	</div>
+
+	<?php do_action( 'woocommerce_checkout_after_order_review' ); ?>
+
+</form>
+
+<?php do_action( 'woocommerce_after_checkout_form', $checkout ); ?>

--- a/woocommerce/global/wrapper-end.php
+++ b/woocommerce/global/wrapper-end.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Content wrappers
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/global/wrapper-end.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see         https://docs.woocommerce.com/document/template-structure/
+ * @package     WooCommerce/Templates
+ * @version     3.3.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+?>
+</main></div>

--- a/woocommerce/global/wrapper-start.php
+++ b/woocommerce/global/wrapper-start.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Content wrappers
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/global/wrapper-start.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see         https://docs.woocommerce.com/document/template-structure/
+ * @package     WooCommerce/Templates
+ * @version     3.3.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+?>
+<div id="primary" class="content-area content-wrap">
+    <main id="main" class="site-main container" role="main">
+


### PR DESCRIPTION
#### What does this PR do?
1. Adds support for Woocommerce plugin
2. Adds Woocommerce templates within the theme
3. Adds and removes certain Woocommerce actions within functions.php
#### Description of Task to be completed?
1. Add support for Woocommerce in setup.php
2. Apply bootstrap classes within the shop page with the global wrappers template
3. Edit the checkout page layout
4. Edit the cart page layout
5. Edit the cart icon dynamically with Woocommerce code
#### How should this be manually tested?
1. As a Wordpress theme, download the zip file and install it into your local or online Wordpress website.
2. Activate the theme.
3. View the website.
4. Create a new page and set the page attribute page as Default
5. Publish and View the page you just set up
6. Install the Woocommerce plugin and run the setup with sample products
7. Add the Woocommerce pages into the Primary menu within the dashboard
8. Click on the cart, shop, checkout, and view cart icon to view the changes.

